### PR TITLE
Feature/import export settings

### DIFF
--- a/src/hydra-core/time_reporting/urls.py
+++ b/src/hydra-core/time_reporting/urls.py
@@ -3,6 +3,7 @@ from django.urls import path
 from .views import (
     CategoryDetail,
     CategoryList,
+    ConfigView,
     ProjectDetail,
     ProjectList,
     TimeRecordDetail,
@@ -37,5 +38,10 @@ urlpatterns = [
         "v1/records/<int:pk>/",
         TimeRecordDetail.as_view(),
         name="record_detail",
+    ),
+    path(
+        "v1/config/",
+        ConfigView.as_view(),
+        name="config",
     ),
 ]

--- a/src/hydra-ui/public/locales/en/translation.json
+++ b/src/hydra-ui/public/locales/en/translation.json
@@ -33,6 +33,7 @@
         "projects": "Projects",
         "records": "Records",
         "reporting": "Reporting",
+        "settings": "Settings",
         "timecards": "Timecards"
     },
     "categories": {
@@ -101,6 +102,29 @@
         },
         "updateSuccessNotification": "Successfully updated time record"
     },
+  "settings": {
+      "backupRestoreDrawerTitle": "Backup / Restore",
+      "backup": {
+          "description": "Export as JSON",
+          "downloadButton": "Download",
+          "title": "Backup"
+      },
+      "pageTitle": "Settings",
+      "restore": {
+          "errorImporting": "Error restoring configuration",
+          "errorLoading": "Error loading {{ file }}",
+          "description": "Import from JSON",
+          "showUploadButton": "Upload",
+          "title": "Restore"
+      },
+      "restoreDialog": {
+          "configuration": "Upload JSON file",
+          "restore": "Restore",
+          "restoreLabel1": "Drop JSON file here",
+          "uploadButton": "Upload"
+      },
+      "showDrawerButtonLabel": "Backup/Restore"
+  },
   "timecards": {
       "categoryLabel": "Category",
       "projectLabel": "Project",

--- a/src/hydra-ui/src/App.tsx
+++ b/src/hydra-ui/src/App.tsx
@@ -14,7 +14,7 @@ import { CategoryDetailView } from "./components/Categories/CategoriesDetailView
 import { ProjectView } from "./components/Projects/ProjectView";
 import { ProjectDetailView } from "./components/Projects/ProjectDetailView";
 import { RecordView } from "./components/Records/RecordView";
-import { RecordDetailView } from "./components/Records/RecordDetailView";
+import { SettingsView } from "./components/Settings/SettingsView";
 import { TimecardView } from "./components/Timecard/TimecardView";
 
 const App: FC<{}> = () => {
@@ -29,15 +29,14 @@ const App: FC<{}> = () => {
                 <Route path="" element={<MainApp />}>
                   <Route path="" element={<Navigate to="records" />} />
                   <Route path="home" element={<Error404 />} />
+                  <Route path="records" element={<RecordView />} />
                   <Route path="categories" element={<CategoryView />}>
                     <Route path=":id" element={<CategoryDetailView />} />
                   </Route>
                   <Route path="projects" element={<ProjectView />}>
                     <Route path=":id" element={<ProjectDetailView />} />
                   </Route>
-                  <Route path="records" element={<RecordView />}>
-                    <Route path=":id" element={<RecordDetailView />} />
-                  </Route>
+                  <Route path="settings" element={<SettingsView />} />
                   <Route path="history" element={<Error404 />} />
                   <Route path="timecards" element={<TimecardView />} />
                 </Route>

--- a/src/hydra-ui/src/api/Settings/index.ts
+++ b/src/hydra-ui/src/api/Settings/index.ts
@@ -1,0 +1,11 @@
+import { instance as axios } from "../axios-instance";
+
+export const downloadConfiguration = () => {
+  const response = axios.get<any>(`/config/`);
+  return response;
+};
+
+export const uploadConfiguration = (data: any) => {
+  const response = axios.put<any>(`/config/`, data);
+  return response;
+};

--- a/src/hydra-ui/src/assets/less/main.less
+++ b/src/hydra-ui/src/assets/less/main.less
@@ -14,6 +14,8 @@
 @import (less) "components/loading-overlay.less";
 @import (less) "components/flextable.less";
 
+@import (less) "../../components/Settings/Settings.less";
+@import (less) "../../components/Shared/CardHeader.less";
 @import (less) "../../components/Shared/Toolbar.less";
 @import (less) "../../components/Shared/MainHeader/MainHeader.less";
 

--- a/src/hydra-ui/src/components/Core/Nav.tsx
+++ b/src/hydra-ui/src/components/Core/Nav.tsx
@@ -62,6 +62,12 @@ export const Nav: FC = () => {
               <span>{t("navigation.projects")}</span>
             </Link>
           </Menu.Item>
+
+          <Menu.Item key="/settings" icon={<SettingOutlined />}>
+            <Link to="/settings">
+              <span>{t("navigation.settings")}</span>
+            </Link>
+          </Menu.Item>
         </Menu.ItemGroup>
 
         <Menu.ItemGroup

--- a/src/hydra-ui/src/components/Settings/Settings.less
+++ b/src/hydra-ui/src/components/Settings/Settings.less
@@ -1,0 +1,36 @@
+.settings-card {
+  margin-bottom: 16px;
+
+  .ant-card-body {
+    max-width: 820px;
+  }
+
+  .ant-card-head-title {
+    max-width: 820px;
+  }
+}
+
+.import-json-preview {
+  height: 300px;
+  overflow: auto;
+
+  pre {
+    background: @dark1;
+    font-family: monospace;
+    font-size: 12px;
+    -moz-tab-size: 4;
+    -o-tab-size: 4;
+    tab-size: 4;
+    white-space: pre;
+  }
+}
+
+.import-json-file {
+  display: flex;
+  margin-bottom: 8px;
+  align-items: center;
+
+  button {
+    margin-left: auto;
+  }
+}

--- a/src/hydra-ui/src/components/Settings/SettingsBackup.tsx
+++ b/src/hydra-ui/src/components/Settings/SettingsBackup.tsx
@@ -1,0 +1,40 @@
+import { DownloadOutlined } from "@ant-design/icons";
+import { Button } from "antd";
+import { format } from "date-fns";
+import { FC, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { downloadConfiguration } from "../../api/Settings";
+
+type Props = {};
+
+export const SettingsBackup: FC<Props> = (props) => {
+  const { t } = useTranslation();
+  const [isDownloading, setIsDownloading] = useState<boolean>(false);
+
+  const download = async () => {
+    try {
+      setIsDownloading(true);
+      const json = await downloadConfiguration();
+      const timestamp = format(new Date(), "yyyyLLddkkmmss");
+      const url = window.URL.createObjectURL(
+        new Blob([JSON.stringify(json.data, null, 2)])
+      );
+      const link = document.createElement("a");
+      link.href = url;
+      link.setAttribute("download", `config-${timestamp}.json`);
+      document.body.appendChild(link);
+      link.click();
+      link.parentNode!.removeChild(link);
+      setIsDownloading(false);
+    } catch (err) {
+      console.log(err);
+      setIsDownloading(false);
+    }
+  };
+
+  return (
+    <Button onClick={download} loading={isDownloading}>
+      <DownloadOutlined /> {t("settings.backup.downloadButton")}
+    </Button>
+  );
+};

--- a/src/hydra-ui/src/components/Settings/SettingsRestore.tsx
+++ b/src/hydra-ui/src/components/Settings/SettingsRestore.tsx
@@ -1,0 +1,25 @@
+import { UploadOutlined } from "@ant-design/icons";
+import { Button } from "antd";
+import { FC, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { SettingsRestoreDialog } from "./SettingsRestoreDialog";
+
+type Props = {
+  disabled: boolean;
+};
+
+export const SettingsRestore: FC<Props> = ({ disabled }) => {
+  const { t } = useTranslation();
+  const [showUpload, setShowUpload] = useState(false);
+
+  return (
+    <div>
+      {showUpload && (
+        <SettingsRestoreDialog onAfterClose={() => setShowUpload(false)} />
+      )}
+      <Button onClick={() => setShowUpload(true)} disabled={disabled}>
+        <UploadOutlined /> {t("settings.restore.showUploadButton")}
+      </Button>
+    </div>
+  );
+};

--- a/src/hydra-ui/src/components/Settings/SettingsRestoreDialog.tsx
+++ b/src/hydra-ui/src/components/Settings/SettingsRestoreDialog.tsx
@@ -1,0 +1,178 @@
+import {
+  CaretDownOutlined,
+  CaretRightOutlined,
+  LoadingOutlined,
+  UploadOutlined,
+} from "@ant-design/icons";
+import { Alert, Button, Modal } from "antd";
+import Upload, { UploadChangeParam } from "antd/lib/upload";
+import { FC, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { uploadConfiguration } from "../../api/Settings";
+import { ModalTitle } from "../Shared/ModalTitle";
+const { Dragger } = Upload;
+
+export enum UploadStatus {
+  NONE = "None",
+  CANCELLED = "Cancelled",
+  LOADING = "Loading",
+  LOAD_ERROR = "LoadError",
+  LOADED = "Loaded",
+  IMPORTING = "Importing",
+  IMPORT_ERROR = "ImportError",
+  COMPLETE = "Complete",
+}
+
+export type UploadedFile = {
+  filename: string;
+  size: number;
+};
+
+type Props = {
+  onAfterClose: () => void;
+};
+
+export const SettingsRestoreDialog: FC<Props> = ({ onAfterClose }) => {
+  const { t } = useTranslation();
+  const [status, setStatus] = useState<UploadStatus>(UploadStatus.NONE);
+  const [file, setFile] = useState<UploadedFile | null>(null);
+  const [importError, setImportError] = useState<string>("");
+  const [data, setData] = useState<any>(null);
+
+  const customRequest = () => {};
+
+  const importConfiguration = async () => {
+    setStatus(UploadStatus.IMPORTING);
+    try {
+      await uploadConfiguration(data);
+      setStatus(UploadStatus.COMPLETE);
+      window.location.reload();
+    } catch (err: any) {
+      setImportError(JSON.stringify(err.errors, null, 4));
+      setStatus(UploadStatus.IMPORT_ERROR);
+    }
+  };
+
+  const onUploadChange = (info: UploadChangeParam) => {
+    function onReaderLoad(event: ProgressEvent<FileReader>) {
+      try {
+        const json = JSON.parse(event.target!.result! as string);
+        setStatus(UploadStatus.LOADED);
+        setData(json);
+      } catch (err) {
+        setStatus(UploadStatus.LOAD_ERROR);
+      }
+    }
+
+    setStatus(UploadStatus.LOADING);
+    setFile({
+      filename: info.file.name!,
+      size: info.file.originFileObj?.size!,
+    });
+    var reader = new FileReader();
+    reader.onload = onReaderLoad;
+    reader.readAsText(info.file.originFileObj!);
+  };
+
+  const canImport = [UploadStatus.LOADED, UploadStatus.IMPORT_ERROR].includes(
+    status
+  );
+
+  const footer = [
+    <Button key="cancel" onClick={() => setStatus(UploadStatus.CANCELLED)}>
+      {t("common.cancel")}
+    </Button>,
+    <Button
+      key="import"
+      type="primary"
+      onClick={importConfiguration}
+      disabled={!canImport}
+      loading={status === UploadStatus.IMPORTING}
+    >
+      {t("settings.restoreDialog.uploadButton")}
+    </Button>,
+  ];
+
+  return (
+    <Modal
+      title={
+        <ModalTitle
+          icon={<UploadOutlined />}
+          title={t("settings.restoreDialog.restore")}
+          subtitle={t("settings.restoreDialog.configuration")}
+        />
+      }
+      footer={footer}
+      width={640}
+      visible={
+        status !== UploadStatus.COMPLETE && status !== UploadStatus.CANCELLED
+      }
+      confirmLoading={false}
+      onCancel={() => {}}
+      maskClosable={true}
+      afterClose={onAfterClose}
+    >
+      {[UploadStatus.NONE, UploadStatus.LOAD_ERROR].includes(status) && (
+        <Dragger
+          style={{ backgroundColor: "transparent", marginBottom: "8px" }}
+          multiple={false}
+          accept=".json"
+          customRequest={customRequest}
+          onChange={onUploadChange}
+          showUploadList={false}
+        >
+          <UploadOutlined style={{ fontSize: "16px", marginBottom: "8px" }} />
+          <p>{t("settings.restoreDialog.restoreLabel1")}</p>
+        </Dragger>
+      )}
+      {file && status !== UploadStatus.LOAD_ERROR && (
+        <div className="import-json-file">{file.filename}</div>
+      )}
+      {status === UploadStatus.LOADING && (
+        <div style={{ textAlign: "center" }}>
+          <LoadingOutlined />
+        </div>
+      )}
+      {status === UploadStatus.LOAD_ERROR && (
+        <Alert
+          type="error"
+          message={t("settings.restore.errorLoading", {
+            file: file?.filename,
+          })}
+        />
+      )}
+      {status === UploadStatus.IMPORT_ERROR && (
+        <ImportError error={importError} />
+      )}
+    </Modal>
+  );
+};
+
+type ImportErrorProps = {
+  error: string;
+};
+
+const ImportError: FC<ImportErrorProps> = ({ error }) => {
+  const { t } = useTranslation();
+  const [expanded, setExpanded] = useState(false);
+  if (!error) return null;
+
+  const content = (
+    <>
+      <span
+        onClick={() => setExpanded((exp) => !exp)}
+        style={{ cursor: "pointer" }}
+      >
+        {expanded ? <CaretDownOutlined /> : <CaretRightOutlined />}
+      </span>
+      {t("settings.restore.errorImporting")}
+      {expanded && <div>{error}</div>}
+    </>
+  );
+
+  return (
+    <div style={{ marginTop: "12px" }}>
+      <Alert type="error" message={content} />
+    </div>
+  );
+};

--- a/src/hydra-ui/src/components/Settings/SettingsView.tsx
+++ b/src/hydra-ui/src/components/Settings/SettingsView.tsx
@@ -1,0 +1,69 @@
+import { FC, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Button, Card, Drawer, Layout } from "antd";
+import { MenuFoldOutlined } from "@ant-design/icons";
+import { MainHeader } from "../Shared/MainHeader/MainHeader";
+import { Toolbar, ToolbarGroup } from "../Shared/Toolbar";
+import { CardHeader } from "../Shared/CardHeader";
+import { SettingsBackup } from "./SettingsBackup";
+import { SettingsRestore } from "./SettingsRestore";
+
+export const SettingsView: FC = () => {
+  const { t } = useTranslation();
+  const [drawerOpen, showDrawer] = useState<boolean>(false);
+
+  return (
+    <Layout.Content>
+      <MainHeader title={t("settings.pageTitle")} />
+
+      <Toolbar>
+        <ToolbarGroup align="right">
+          <Button onClick={() => showDrawer(true)}>
+            <MenuFoldOutlined />
+            {t("settings.showDrawerButtonLabel")}
+          </Button>
+        </ToolbarGroup>
+      </Toolbar>
+
+      <Drawer
+        title={t("settings.backupRestoreDrawerTitle")}
+        placement="right"
+        closable={true}
+        width={720}
+        afterVisibleChange={(visible) => {
+          visible !== drawerOpen && showDrawer(visible);
+        }}
+        onClose={() => showDrawer(false)}
+        visible={drawerOpen}
+      >
+        <Card
+          className="settings-card"
+          bordered={true}
+          title={
+            <CardHeader
+              title={t("settings.backup.title")}
+              description={t("settings.backup.description")}
+            />
+          }
+        >
+          <SettingsBackup />
+        </Card>
+
+        {true && (
+          <Card
+            className="settings-card"
+            bordered={true}
+            title={
+              <CardHeader
+                title={t("settings.restore.title")}
+                description={t("settings.restore.description")}
+              />
+            }
+          >
+            <SettingsRestore disabled={false} />
+          </Card>
+        )}
+      </Drawer>
+    </Layout.Content>
+  );
+};

--- a/src/hydra-ui/src/components/Shared/CardHeader.less
+++ b/src/hydra-ui/src/components/Shared/CardHeader.less
@@ -1,0 +1,33 @@
+.card-header {
+  display: flex;
+  flex-direction: row;
+  min-height: 32px;
+  overflow: hidden;
+
+  small {
+    display: block;
+    font-size: 16px;
+    font-weight: normal;
+  }
+
+  &__left {
+    flex: 1;
+    overflow: hidden;
+  }
+
+  &__actions {
+    margin-left: auto;
+    white-space: nowrap;
+    flex: 0;
+    margin-left: 8px;
+  }
+
+  .ant-typography {
+    margin: 0;
+    line-height: 32px;
+  }
+
+  + * {
+    margin-top: 24px;
+  }
+}

--- a/src/hydra-ui/src/components/Shared/CardHeader.tsx
+++ b/src/hydra-ui/src/components/Shared/CardHeader.tsx
@@ -1,0 +1,37 @@
+import { FC, ReactNode } from "react";
+import { Outlet } from "react-router-dom";
+import styled from "styled-components";
+import { Typography } from "antd";
+
+const CardHeaderDiv = styled.div``;
+const CardHeaderLeft = styled.div``;
+const CardHeaderActions = styled.div``;
+const CardHeaderTitle = styled.div``;
+
+interface Props {
+  title: string | ReactNode;
+  subtitle?: string;
+  description?: string;
+  dropdownMenu?: ReactNode;
+}
+
+export const CardHeader: FC<Props> = (props) => {
+  const { title, subtitle, description } = props;
+
+  return (
+    <CardHeaderDiv className="card-header">
+      <CardHeaderLeft>
+        <CardHeaderTitle className="card-header-title">
+          {title}
+          {subtitle && <small>{subtitle}</small>}
+        </CardHeaderTitle>
+        {description && (
+          <Typography.Text type="secondary">{description}</Typography.Text>
+        )}
+      </CardHeaderLeft>
+      <CardHeaderActions className="card-header-actions">
+        <Outlet />
+      </CardHeaderActions>
+    </CardHeaderDiv>
+  );
+};


### PR DESCRIPTION
This adds a new "Settings" page in the Navigation menu with a pop-out
drawer for bacukp/restore.  The backup/restore options use a new API at
"/v1/config/" that will download and replace existing configuration and
data.

closes #66
opens #136

Support exporting configuration via GET /v1/config/

Add service method for importing configuration

Backend API for config import/export

Fix unit test and linting error

New settings page that can download configuration

Support restoring configuration

Signed-off-by: Anthony Oteri <anthony.oteri@edgeware.tv>