### PR TITLE
Prevent deleting categories and projects with records

### DIFF
--- a/src/hydra-core/time_reporting/views.py
+++ b/src/hydra-core/time_reporting/views.py
@@ -13,6 +13,7 @@ from rest_framework.serializers import (
     ModelSerializer,
     PrimaryKeyRelatedField,
     Serializer,
+    SerializerMethodField,
     SlugRelatedField,
 )
 
@@ -29,8 +30,12 @@ class CategoryList(BaseAPIView):
         id = IntegerField()
         name = CharField()
         description = CharField(allow_null=True, allow_blank=True)
+        num_records = SerializerMethodField()
         created = DateTimeField()
         updated = DateTimeField()
+
+        def get_num_records(self, obj):
+            return sum([p.records.count() for p in obj.projects.all()])
 
     class InputSerializer(Serializer):
         name = CharField()
@@ -70,12 +75,18 @@ class CategoryList(BaseAPIView):
 
 class CategoryDetail(BaseAPIView):
     class OutputSerializer(ModelSerializer):
+        num_records = SerializerMethodField()
+
+        def get_num_records(self, obj):
+            return sum([p.records.count() for p in obj.projects.all()])
+
         class Meta:
             model = Category
             fields = (
                 "id",
                 "name",
                 "description",
+                "num_records",
                 "created",
                 "updated",
             )
@@ -139,8 +150,12 @@ class ProjectList(BaseAPIView):
         category = PrimaryKeyRelatedField(queryset=Category.objects.all())
         name = CharField()
         description = CharField(allow_blank=True, allow_null=True)
+        num_records = SerializerMethodField()
         created = DateTimeField()
         updated = DateTimeField()
+
+        def get_num_records(self, obj):
+            return obj.records.count()
 
     class InputSerializer(Serializer):
         name = CharField()
@@ -179,6 +194,11 @@ class ProjectList(BaseAPIView):
 
 class ProjectDetail(BaseAPIView):
     class OutputSerializer(ModelSerializer):
+        num_records = SerializerMethodField()
+
+        def get_num_records(self, obj):
+            return obj.records.count()
+
         class Meta:
             model = Project
             fields = (
@@ -186,6 +206,7 @@ class ProjectDetail(BaseAPIView):
                 "name",
                 "category",
                 "description",
+                "num_records",
                 "created",
                 "updated",
             )

--- a/src/hydra-ui/public/locales/en/translation.json
+++ b/src/hydra-ui/public/locales/en/translation.json
@@ -47,7 +47,9 @@
         "createSuccessNotification": "Successfully create new category",
         "table": {
             "descriptionLabel": "Description",
-            "nameLabel": "Category"
+            "nameLabel": "Category",
+            "numRecordsLabel": "Number of Records",
+            "unused": "Never used"
         },
         "updateSuccessNotification": "Successfully updated category"
     },
@@ -67,7 +69,9 @@
         "table": {
             "categoryLabel": "Category",
             "descriptionLabel": "Description",
-            "nameLabel": "Project"
+            "nameLabel": "Project",
+            "numRecordsLabel": "Number of Records",
+            "unused": "Never used"
         },
         "updateSuccessNotification": "Successfully updated project"
     },

--- a/src/hydra-ui/src/api/TimeReporting/types.ts
+++ b/src/hydra-ui/src/api/TimeReporting/types.ts
@@ -2,24 +2,26 @@ export interface Category {
   id: number;
   name: string;
   description: string;
+  num_records?: number;
   created?: Date;
   updated?: Date;
 }
 
 export interface CategoryDraft
-  extends Omit<Category, "id" | "created" | "updated"> {}
+  extends Omit<Category, "id" | "num_records" | "created" | "updated"> {}
 
 export interface Project {
   id: number;
   name: string;
   description: string;
   category: number;
+  num_records?: number;
   created?: Date;
   updated?: Date;
 }
 
 export interface ProjectDraft
-  extends Omit<Project, "id" | "created" | "updated"> {}
+  extends Omit<Project, "id" | "num_records" | "created" | "updated"> {}
 
 export interface TimeRecord {
   id: number;

--- a/src/hydra-ui/src/components/Categories/CategoriesTable.tsx
+++ b/src/hydra-ui/src/components/Categories/CategoriesTable.tsx
@@ -35,6 +35,9 @@ export const CategoriesTable: FC<Props> = (props: Props) => {
           key={`category_${index}_delete`}
           onClick={() => onDelete(category)}
           data-testid={`category_${index}_delete`}
+          disabled={
+            category.num_records && category.num_records >= 0 ? true : false
+          }
         >
           <DeleteOutlined />
           {t("common.delete")}
@@ -54,6 +57,18 @@ export const CategoriesTable: FC<Props> = (props: Props) => {
           </Link>
         );
       },
+      sorter: (a: Category, b: Category) => a.name.localeCompare(b.name),
+    },
+    {
+      title: () => <>{t("categories.table.numRecordsLabel")}</>,
+      className: "column--num-records",
+      render: (value: any, category: Category, index: number) => {
+        return (
+          <span>{category.num_records || t("categories.table.unused")}</span>
+        );
+      },
+      sorter: (a: Category, b: Category) =>
+        (a.num_records || 0) - (b?.num_records || 0),
     },
     {
       title: () => <>{t("categories.table.descriptionLabel")}</>,

--- a/src/hydra-ui/src/components/Projects/ProjectTable.tsx
+++ b/src/hydra-ui/src/components/Projects/ProjectTable.tsx
@@ -38,6 +38,9 @@ export const ProjectTable: FC<Props> = (props: Props) => {
           key={`project_${index}_delete`}
           onClick={() => onDelete(project)}
           data-testid={`project_${index}_delete`}
+          disabled={
+            project.num_records && project.num_records >= 0 ? true : false
+          }
         >
           <DeleteOutlined />
           {t("common.delete")}
@@ -57,6 +60,7 @@ export const ProjectTable: FC<Props> = (props: Props) => {
           </Link>
         );
       },
+      sorter: (a: Project, b: Project) => a.name.localeCompare(b.name),
     },
     {
       title: () => <>{t("projects.table.categoryLabel")}</>,
@@ -66,6 +70,22 @@ export const ProjectTable: FC<Props> = (props: Props) => {
           <span>{categories.find((c) => c.id === project.category)?.name}</span>
         );
       },
+      sorter: (a: Project, b: Project) => {
+        const aCategory =
+          categories.find((c) => c.id === a.category)?.name || "";
+        const bCategory =
+          categories.find((c) => c.id === b.category)?.name || "";
+        return aCategory.localeCompare(bCategory);
+      },
+    },
+    {
+      title: () => <>{t("projects.table.numRecordsLabel")}</>,
+      className: "column--num-records",
+      render: (value: any, project: Project, index: number) => {
+        return <span>{project.num_records || t("projects.table.unused")}</span>;
+      },
+      sorter: (a: Project, b: Project) =>
+        (a.num_records || 0) - (b?.num_records || 0),
     },
     {
       title: () => <>{t("projects.table.descriptionLabel")}</>,
@@ -74,6 +94,7 @@ export const ProjectTable: FC<Props> = (props: Props) => {
         return <span>{project.description}</span>;
       },
     },
+
     {
       className: "column--actions",
       render: (value: any, project: Project, index: number) => {


### PR DESCRIPTION
This adds the number of records to the internal object representations
for both projects and categories and disables the "delete" menu option
on any project or category with records.  Also the number of records is
now displayed in the table, making it easier to determine which projects
and categories are safe to clean up.

fixes #70

Report number of associated records on each project

Disable the "delete" menu on projects with existing records

Show number of records in project table and allow sorting

Add the number of records to the category views

Add the number of records to the category table

Signed-off-by: Anthony Oteri <anthony.oteri@edgeware.tv>
